### PR TITLE
Add JQ to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER WebOps <webops_team@pebble.com>
 RUN apk --update add \
     python \
     py-pip \
+    jq \
     && pip install awscli \
     && apk del py-pip \
     && rm -rf /var/cache/apk/*


### PR DESCRIPTION
For parsing output when JQ isn't available on the host system (i.e.
non-CoreOS: jenkins slaves).

Maybe this is crazy and I should just add JQ to the slaves; trying to
avoid the first step on that slippery slope.
